### PR TITLE
Revert "added Explore button linking to listings_path both when user logged i…"

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -12,9 +12,6 @@
       <ul class="navbar-nav me-auto">
         <% if user_signed_in? %>
           <li class="nav-item active">
-            <%= link_to "Explore", listings_path, class: "nav-link" %>
-          </li>
-          <li class="nav-item active">
             <%= link_to "Home", "#", class: "nav-link" %>
           </li>
           <li class="nav-item">
@@ -30,11 +27,8 @@
           </li>
         <% else %>
           <li class="nav-item">
-            <li class="nav-item active">
-            <%= link_to "Explore", listings_path, class: "nav-link" %>
-            </li>
-            <li>
             <%= link_to "Login", new_user_session_path, class: "nav-link" %>
+            <%= link_to "Explore", listings_path, class: "nav-link" %>
           </li>
         <% end %>
       </ul>


### PR DESCRIPTION
Reverts sarhan-a/redore#15

The merged code is broken as can be seen in the screenshot. **Login** and **Explore** links are on top of each other. Please don't merge it. 

I would highly suggest reverting navbar to its original code.

![screenshot-2022-08-20-at-21-25-15](https://user-images.githubusercontent.com/2909818/185764899-de597b84-b004-4b6d-a2f6-2a2fbb0d05c1.jpg)
