### PR TITLE
fix explore link in navbar

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -10,6 +10,9 @@
 
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
       <ul class="navbar-nav me-auto">
+        <li class="nav-item">
+          <%= link_to "Explore", listings_path, class: "nav-link" %>
+        </li>
         <% if user_signed_in? %>
           <li class="nav-item active">
             <%= link_to "Home", "#", class: "nav-link" %>
@@ -28,7 +31,6 @@
         <% else %>
           <li class="nav-item">
             <%= link_to "Login", new_user_session_path, class: "nav-link" %>
-            <%= link_to "Explore", listings_path, class: "nav-link" %>
           </li>
         <% end %>
       </ul>


### PR DESCRIPTION
Fixes the **Explore** link in the navbar.

**Logged in view:**
![screenshot-2022-08-20-at-22-01-56](https://user-images.githubusercontent.com/2909818/185765900-84418476-c01c-4d3b-9859-16541b0d45fb.jpg)

**Logged out view:**
![screenshot-2022-08-20-at-22-02-31](https://user-images.githubusercontent.com/2909818/185765912-6aacd427-8f87-441c-b186-b2e88494ab49.jpg)

**Previously:**
![screenshot-2022-08-20-at-22-03-02](https://user-images.githubusercontent.com/2909818/185765928-1d97bdf2-7f50-4ac1-ad8f-8bea096509de.jpg)


