### PR TITLE
disable flatpickr dates for already booked dates

### DIFF
--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -2,6 +2,8 @@ class BookingsController < ApplicationController
   def new
     @listing = Listing.find(params[:listing_id])
     @booking = @listing.bookings.new(user: current_user)
+    @bookings = Booking.where('collection_date >= ? AND collection_date < ?', Time.current, Time.current + 90.days).order(collection_date: :asc)
+    @booked_dates = @bookings.pluck(:collection_date)
   end
 
   def create

--- a/app/views/bookings/new.html.erb
+++ b/app/views/bookings/new.html.erb
@@ -1,12 +1,14 @@
 <div class="container">
   <h1>Book the listing: <%= @listing.title %></h1>
 
-  <%= form_with model: [@listing, Booking.new], authenticity_token: true do |f| %>
+  <%= form_with model: [@listing, @booking] do |f| %>
     <%= f.text_field :collection_date,
       data: {
         controller: "flatpickr",
         flatpickr_date_format: "Y-m-d",
-        flatpickr_min_date: Time.zone.now
+        flatpickr_min_date: Time.current,
+        flatpickr_max_date: Time.current + 90.days,
+        flatpickr_disable: @booked_dates
       },
       placeholder: "Select a date" %>
     <%= f.submit "Confirm Booking" %>


### PR DESCRIPTION
This commit implements **booking availability** by making already booked dates unavailable to be picked in flatpickr. 

See the screen recording for the functionality ↓↓

![booking-availability](https://user-images.githubusercontent.com/2909818/186427745-e485d2c2-7bfb-4e86-a698-d0efa4f17dde.gif)
.