### PR TITLE
restrict user/owner actions on listing show page

### DIFF
--- a/app/views/listings/show.html.erb
+++ b/app/views/listings/show.html.erb
@@ -4,21 +4,28 @@
     <%= cl_image_tag photo.key, height: 300, width: 400, crop: :fill  %>
   <% end %>
   <h2> <%= @listing.address %></h2>
-    <p> <%= @listing.details %></p><br>
-    <p> Only £<%= '%.2f' % @listing.price %> collection fee</p>
+  <p> <%= @listing.details %></p><br>
+  <p> Only £<%= '%.2f' % @listing.price %> collection fee</p>
+
   <div class = "show card links">
     <ul>
+      <!-- User actions -->
       <li> <%= link_to 'Choose another', listings_path %></li>
       <li> <%= link_to 'Back to home', root_path %></li>
-      <li> <%= link_to 'Book now!', new_listing_booking_path(@listing) %></li>
-      <li><%= link_to 'Show bookings', listing_bookings_path(@listing) %></li>
-      <!-- Edit the listing-->
-      <li> <%= link_to 'Edit', edit_listing_path  %></li>
-      <li> <%= link_to 'Leave review', new_listing_review_path(@listing) %></li>
-      <!-- Implement logic at later stage, only owners can delete-->
-      <li> <%= link_to 'Delete', listing_path,
-        data: {turbo_method: :delete, turbo_confirm: "Are you sure?"} %></li>
-      </ul>
+      <!-- Prevent owners from booking or reviewing their own listings -->
+      <% unless current_user == @listing.user %>
+        <li> <%= link_to 'Book now!', new_listing_booking_path(@listing) %></li>
+        <li> <%= link_to 'Leave review', new_listing_review_path(@listing) %></li>
+      <% end %>
+      <!-- Owner actions -->
+      <% if current_user == @listing.user %>
+        <li><%= link_to 'Show bookings', listing_bookings_path(@listing) %></li>
+        <li> <%= link_to 'Edit', edit_listing_path  %></li>
+        <li> <%= link_to 'Delete', listing_path,
+          data: {turbo_method: :delete, turbo_confirm: "Are you sure?"} %></li>
+      <% end %>
+    </ul>
   </div>
-    <%= render "shared/listing_reviews" %>
+
+  <%= render "shared/listing_reviews" %>
 </div>


### PR DESCRIPTION
This commit restricts certain actions for users and owners on a listing's show page.
- A user can book or leave a review. A user cannot show bookings, edit or delete.
- An owner can show bookings, edit or delete. An owner cannot book or leave a review.

![screenshot-2022-08-27-at-11-30-07](https://user-images.githubusercontent.com/2909818/187026314-1c71c5cf-47af-4738-8af5-235e4d6df2df.jpg)

![screenshot-2022-08-27-at-11-31-26](https://user-images.githubusercontent.com/2909818/187026371-21239c78-5d70-410a-94a1-a5f4959662f1.jpg)

