### PR TITLE
fix cloudinary avatar bug

### DIFF
--- a/app/assets/stylesheets/components/_avatar.scss
+++ b/app/assets/stylesheets/components/_avatar.scss
@@ -1,13 +1,10 @@
-.avatar {
-  width: 40px;
+.navbar-avatar-lg {
+  width: 56px;
   border-radius: 50%;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.2);
 }
-.avatar-large {
-  width: 52px;
-  border-radius: 50%;
 
-}
-.avatar-bordered {
+.navbar-avatar-sm {
   width: 42px;
   border-radius: 50%;
   box-shadow: 0 1px 2px rgba(0,0,0,0.2);
@@ -22,10 +19,4 @@
     box-shadow: 0 .25rem .25rem .125rem rgba($orange, .1),
     0 .375rem .75rem -.125rem rgba($orange, .4);
   }
-}
-.avatar-square {
-  width: 40px;
-  border-radius: 0px;
-  box-shadow: 0 1px 2px rgba(0,0,0,0.2);
-  border: white 1px solid;
 }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,7 +1,7 @@
 module ApplicationHelper
   def user_avatar(user)
     if user.avatar.attached?
-      user.avatar
+      cl_image_path user.avatar.key, crop: :fill, gravity: :face, width: 200, height: 200
     else
       gravatar_image_url(user.email)
     end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -7,7 +7,7 @@
   <div class="form-group">
     <div class="row">
       <div class="col-sm-4">
-        <%= image_tag user_avatar(current_user), size: 150, crop: :fill, gravity: :face, class: "rounded-circle" %>
+        <%= image_tag user_avatar(current_user), size: 150, class: "rounded-circle", alt:"profile photo" %>
       </div>
       <div class="col-sm-8">
         <%= f.input :avatar, as: :file %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -13,7 +13,7 @@
         <%= image_tag user_avatar(current_user), class:"navbar-avatar-sm", alt: current_user.first_name + " " + current_user.last_name%>
       <div class="dropdown-menu dropdown-menu-end">
         <div class="d-flex align-items-start border-bottom px-3 py-1 mb-2" style="width: 16rem;">
-           <%= image_tag user_avatar(current_user), class: "navbar-avatar-lg", alt:""%>
+          <%= image_tag user_avatar(current_user), class: "navbar-avatar-lg", alt:""%>
           <div class="ps-2">
             <h6 class="fs-base mb-0"><%= current_user.first_name + " " + current_user.last_name %></h6>
             <div class="fs-xs py-2"><%= current_user.email %></div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -10,10 +10,10 @@
     <div class="dropdown d-none d-lg-block order-lg-3 my-n2 me-3">
     <% if user_signed_in? %>
       <a href="#" class="d-inline-block py-2" data-bs-toggle="dropdown">
-        <%= image_tag user_avatar(current_user), class: "avatar-bordered", alt:"user_avatar" %>
+        <%= image_tag user_avatar(current_user), class:"navbar-avatar-sm", alt: current_user.first_name + " " + current_user.last_name%>
       <div class="dropdown-menu dropdown-menu-end">
         <div class="d-flex align-items-start border-bottom px-3 py-1 mb-2" style="width: 16rem;">
-          <%= image_tag user_avatar(current_user), class: "avatar-large" %>
+           <%= image_tag user_avatar(current_user), class: "navbar-avatar-lg", alt:""%>
           <div class="ps-2">
             <h6 class="fs-base mb-0"><%= current_user.first_name + " " + current_user.last_name %></h6>
             <div class="fs-xs py-2"><%= current_user.email %></div>


### PR DESCRIPTION
fixed an error that was causing the incorrect renderring of avatars from cloudinary (asset was loading from local pipeline rather than Cloudinary servers). 
- everything should now work as expected:
i.e.:  A new user will have a Gravatar (either default or personal) shown until they upload a new picture, which is handled via Cloudinary helpers.

- removed some unused avatar styling
- added img alt descriptions