### PR TITLE
replace global h2 style with class to fix h2 style issues

### DIFF
--- a/app/assets/stylesheets/components/_how_to_cards.scss
+++ b/app/assets/stylesheets/components/_how_to_cards.scss
@@ -14,6 +14,6 @@
 .card-hover[class^=bg-]:hover, .card-hover[class*=" bg-"]:hover, .card-hover[class*=" bg-"].active, .card-hover[class*=" bg-"].show {
   background-color: #fff !important;
 }
-h2 {
+.card-number {
   font-size: 4rem;
 }

--- a/app/views/shared/_how_to_cards.html.erb
+++ b/app/views/shared/_how_to_cards.html.erb
@@ -5,7 +5,7 @@
       <div class="card card-hover card-body border-0 bg-transparent">
         <%= image_tag image_url("how_to_search.png"), class: "card-img-top p-5" %>
         <div class="d-flex mt-3">
-          <div class="h2 text-primary my-2">1</div>
+          <div class="h2 text-primary my-2 card-number">1</div>
           <div class="ms-3 mt-3">
             <h3 class="h5 card-title">Search Listings</h3>
             <p class="card-text fs-sm">Search for businesses that can collect and recycle your domestic or commercial waste.</p>
@@ -17,7 +17,7 @@
       <div class="card card-hover card-body border-0 bg-transparent">
         <%= image_tag image_url("how_to_book.png"), class: "card-img-top p-5" %>
         <div class="d-flex mt-3">
-          <div class="h2 text-primary my-2">2</div>
+          <div class="h2 text-primary my-2 card-number">2</div>
           <div class="ms-3 mt-3">
             <h3 class="h5 card-title">Book Online</h3>
             <p class="card-text fs-sm">Tell us which day and time works best for you. We even offer same-day collections.</p>
@@ -29,7 +29,7 @@
       <div class="card card-hover card-body border-0 bg-transparent">
         <%= image_tag image_url("how_to_collect.png"), class: "card-img-top p-5" %>
         <div class="d-flex mt-3">
-          <div class="h2 text-primary my-2">3</div>
+          <div class="h2 text-primary my-2 card-number">3</div>
           <div class="ms-3 mt-3">
             <h3 class="h5 card-title">Wait for Collection</h3>
             <p class="card-text fs-sm">Our friendly team will remove and recycle your domestic or commercial waste.</p>


### PR DESCRIPTION
This commit fixes issue #61, by removing the global style for `h2` elements and replacing it with the class `card-number`.