### PR TITLE
style the breadcrumb nav

### DIFF
--- a/app/assets/stylesheets/components/_breadcrumbs.scss
+++ b/app/assets/stylesheets/components/_breadcrumbs.scss
@@ -1,0 +1,28 @@
+.breadcrumb {
+  display: flex;
+  flex-wrap: wrap;
+  padding: 0 0;
+  margin-bottom: 1rem;
+  font-size: 0.9rem;
+  list-style: none;
+  background-color: transparent;
+}
+
+.breadcrumb-item.active{
+  color: $orange;
+}
+
+.breadcrumb a {
+  transition: color .2s ease-in-out;
+}
+
+.breadcrumb .breadcrumb-item {
+  > a {
+    color: #9691a4;
+    text-decoration: none;
+
+    &:hover {
+      color: $mauve;
+    }
+  }
+}

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -12,3 +12,4 @@
 @import "filtering";
 @import "card_booking";
 @import "card_business";
+@import "breadcrumbs";

--- a/app/views/shared/_breadcrumbs.html.erb
+++ b/app/views/shared/_breadcrumbs.html.erb
@@ -6,8 +6,9 @@
       </li>
       <% @breadcrumbs.each do |breadcrumb| %>
         <% if breadcrumb[:path].nil? %>
-          <li class="breadcrumb-item active" aria-current="page"></li>
+          <li class="breadcrumb-item active" aria-current="page">
             <%= breadcrumb[:label] %>
+          </li>
         <% else %>
           <li class="breadcrumb-item">
             <%= link_to breadcrumb[:label], breadcrumb[:path] %>


### PR DESCRIPTION
- css rules to override the default bootstrap style for the breadcrumb nav
- smaller font, removed link decoration, add hover and reversed colour highlights