### PR TITLE
fix bug - edit listing was deleting pictures if no picture was selected

### DIFF
--- a/app/views/listings/edit.html.erb
+++ b/app/views/listings/edit.html.erb
@@ -1,8 +1,10 @@
-<%= simple_form_for @listing do |f| %>
-<%= f.input :title %>
-<%= f.input :address %>
-<%= f.input :details %>
-<%= f.input :price %>
-<%= f.input :photos, as: :file, input_html: { multiple: true } %>
-<%= f.submit class: 'btn btn-primary' %>
-<% end %>
+<div class="container col-8 mt-5 text-center">
+  <%= simple_form_for @listing do |f| %>
+    <%= f.input :title %>
+    <%= f.input :address %>
+    <%= f.input :details %>
+    <%= f.input :price %>
+    <%= f.input :photos, as: :file, input_html: { multiple: true } %>
+    <%= f.submit class: 'btn btn-primary mt-5' %>
+  <% end %>
+</div>

--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -1,0 +1,8 @@
+# when editing entries with (has many) photos attached this prevents purge of photos after edit
+# if photos exist? new photos will be added to the existing ones, if no photo is selected, previous picture persist.
+# this file is effective both in dev and prod via config/initializers/active_storage.rb
+# if you want to disable / enable this rule only in either dev or prod add the line below in config/environments/development.rb
+# or production.rb respectively and delete this file.
+# config.active_storage.replace_on_assign_to_many = false
+
+Rails.application.config.active_storage.replace_on_assign_to_many = false


### PR DESCRIPTION
This also fixes the other scenario: when adding new photos via edit, the old ones wouldn't persist. 
For our use case this is ideal at the moment. In the future, implement a way of deleting selectively from existing photos.