### PR TITLE
fixed link in favorites index to open favorited company

### DIFF
--- a/app/controllers/favorite_listings_controller.rb
+++ b/app/controllers/favorite_listings_controller.rb
@@ -3,13 +3,13 @@ class FavoriteListingsController < ApplicationController
   before_action :add_index_breadcrumb, only: %i[index]
 
   def index
-    @favourites = current_user.favorite_listings
+    @favorites = current_user.favorite_listings
     add_breadcrumb('Wishlist')
   end
 
   def create
     if Favorite.create(favorited: @listing, user: current_user)
-      redirect_to @listing, notice: 'Listing added to favourites'
+      redirect_to @listing, notice: 'Company saved to your favourites'
     else
       redirect_to @listing, alert: 'Something went wrong...'
     end
@@ -17,7 +17,7 @@ class FavoriteListingsController < ApplicationController
 
   def destroy
     Favorite.where(favorited_id: @listing.id, user_id: current_user.id).first.destroy
-    redirect_to @listing, notice: 'Listing is no longer in your favourites'
+    redirect_to @listing, notice: 'Company removed from your favourites'
   end
 
   private

--- a/app/views/favorite_listings/index.html.erb
+++ b/app/views/favorite_listings/index.html.erb
@@ -56,12 +56,12 @@
         <h1 class="h2 mb-0">Your Wishlist</h1><a class="fw-bold text-decoration-none" href="#"><i class="fa-solid fa-xmark fs-xs mt-n1 me-2"></i>Clear all</a>
       </div>
       <!-- Item-->
-      <% if @favourites.empty? %>
+      <% if @favorites.empty? %>
         <p>Nothing added yet, listings liked in results will appear here.</p>
       <% else %>
 
-      <% @favourites.each do |favorite| %>
-      <%= link_to listings_path do %>
+      <% @favorites.each do |favorite| %>
+      <%= link_to favorite do %>
       <div class="card-product mb-3">
         <div class="row g-0">
           <div class="col-md-4">

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -29,7 +29,7 @@
         <% end %>
         <%= link_to favorites_path, class:"dropdown-item" do %>
           <i class="fa-regular fa-heart me-2"></i>
-          Wishlist
+          Favourites
         <% end %>
         <a href="#" class="dropdown-item">
           <i class="fa-regular fa-star me-2"></i>


### PR DESCRIPTION
Fixed the link for each favorited company in Favourites view to direct to that specific favorited company as previously it was leading to all listings. 

- minor changes in spelling  (favorite / favourite) - sticking to US spelling in backend as easier and UK spelling in Views.
- renamed "Wishlist" to "Favourites" and rephrased notifications.
