### PR TITLE
Navbar dropdown email address overflow fix

### DIFF
--- a/app/assets/stylesheets/components/_avatar.scss
+++ b/app/assets/stylesheets/components/_avatar.scss
@@ -1,19 +1,17 @@
-.review-avatar {
-  width: 48px;
+.circle {
   border-radius: 50%;
-  box-shadow: 0 1px 2px rgba(0,0,0,0.2);
 }
 
-.navbar-avatar-lg {
+.avatar-lg {
   width: 56px;
-  border-radius: 50%;
-  box-shadow: 0 1px 2px rgba(0,0,0,0.2);
 }
 
-.navbar-avatar-sm {
+.avatar-md {
+  width: 48px;
+}
+
+.avatar-sm {
   width: 42px;
-  border-radius: 50%;
-  box-shadow: 0 1px 2px rgba(0,0,0,0.2);
   border: white 1px solid;
 
   &:hover,
@@ -23,6 +21,12 @@
     border-color: darken($orange, 7%);
     color: $white;
     box-shadow: 0 .25rem .25rem .125rem rgba($orange, .1),
-    0 .375rem .75rem -.125rem rgba($orange, .4);
+      0 .375rem .75rem -.125rem rgba($orange, .4);
   }
+}
+
+.avatar-lg,
+.avatar-md,
+.avatar-sm {
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
 }

--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -25,7 +25,20 @@
   }
 }
 
+.dropdown-head {
+  text-decoration: none;
+}
+
+.dropdown-head-eml {
+  font-size: 0.7rem;
+  color: $mauve;
+  box-sizing: content-box;
+  padding-right: 0.5rem;
+}
+
 .dropdown-menu {
+  overflow: hidden;
+
   .dropdown-item {
     color: $mauve;
     font-weight: 400;

--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -12,27 +12,28 @@
   height: 54px;
   object-fit: cover;
 }
-  .navbar-nav {
-    .nav-link {
-      color: $mauve;
-      font-weight: bold;
 
-      &:hover,
-      &:focus {
-        color: $orange;
-      }
+.navbar-nav {
+  .nav-link {
+    color: $mauve;
+    font-weight: bold;
+
+    &:hover,
+    &:focus {
+      color: $orange;
     }
   }
+}
 
-  .dropdown-menu {
-    .dropdown-item {
-      color: $mauve;
-      font-weight: 400;
+.dropdown-menu {
+  .dropdown-item {
+    color: $mauve;
+    font-weight: 400;
 
-      &:hover,
-      &:focus {
-        color: $orange;
-        background: transparent;
-      }
+    &:hover,
+    &:focus {
+      color: $orange;
+      background: transparent;
     }
   }
+}

--- a/app/assets/stylesheets/config/_bootstrap_variables.scss
+++ b/app/assets/stylesheets/config/_bootstrap_variables.scss
@@ -9,6 +9,7 @@ $headings-font-family: $headers-font;
 $body-bg: $white;
 $font-size-base: 1rem;
 
+
 // Colors
 $body-color: $gray;
 $primary: $orange;

--- a/app/assets/stylesheets/config/_fonts.scss
+++ b/app/assets/stylesheets/config/_fonts.scss
@@ -14,3 +14,7 @@ $headers-font: 'Noto Sans', 'sans-serif';
 //        font-url('FontFile.ttf') format('truetype')
 // }
 // $my-font: "Font Name";
+
+.fs-xs {
+  font-size: 0.688rem;
+}

--- a/app/assets/stylesheets/config/_fonts.scss
+++ b/app/assets/stylesheets/config/_fonts.scss
@@ -14,7 +14,3 @@ $headers-font: 'Noto Sans', 'sans-serif';
 //        font-url('FontFile.ttf') format('truetype')
 // }
 // $my-font: "Font Name";
-
-.fs-xs {
-  font-size: 0.688rem;
-}

--- a/app/views/favorite_listings/index.html.erb
+++ b/app/views/favorite_listings/index.html.erb
@@ -6,7 +6,7 @@
     <!-- Account nav-->
       <div class="card-profile-large border-0 shadow pb-1 me-lg-1">
         <div class="d-flex d-md-block d-lg-flex align-items-start pt-lg-2 mb-4">
-          <%= image_tag user_avatar(current_user), class: "navbar-avatar-lg", alt:""%>
+          <%= image_tag user_avatar(current_user), class: "avatar-lg circle", alt:""%>
           <div class="profile-header pt-md-2 pt-lg-0 ps-3 ps-md-0 ps-lg-3">
             <h4 class="fs-lg mb-0"><%= current_user.first_name + " " + current_user.last_name %></h4>
             <ul class="list-unstyled fs-sm mt-3 mb-0">

--- a/app/views/shared/_listing_reviews.html.erb
+++ b/app/views/shared/_listing_reviews.html.erb
@@ -29,7 +29,7 @@
   <div class="mb-4 pb-4 border-bottom">
     <div class="d-flex justify-content-between mb-3">
       <div class="d-flex align-items-center pe-2">
-        <%= image_tag user_avatar(review.user), class: "review-avatar", alt:""%>
+        <%= image_tag user_avatar(review.user), class: "avatar-md circle", alt:""%>
         <div class="ps-2">
           <h6 class="fs-base mb-0"><%= review.user.first_name+ ' ' +review.user.last_name %></h6>
           <span class="star-rating">

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -15,8 +15,8 @@
         <div class="d-flex align-items-start border-bottom px-3 py-1 mb-2" style="width: 16rem;">
           <%= image_tag user_avatar(current_user), class: "avatar-md circle", alt:""%>
           <div class="ps-2">
-            <h6 class="fs-base mb-0"><%= current_user.first_name + " " + current_user.last_name %></h6>
-            <div class="fs-8 py-2"><%= current_user.email %></div>
+            <h6 class="mb-0"><%= current_user.first_name + " " + current_user.last_name %></h6>
+            <div class="fs-xs py-2"><%= current_user.email %></div>
           </div>
         </div>
         <%= link_to edit_user_registration_path, class:"dropdown-item" do %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -9,14 +9,14 @@
     <!-- Only if user is signed in -->
     <div class="dropdown d-none d-lg-block order-lg-3 my-n2 me-3">
     <% if user_signed_in? %>
-      <a href="#" class="d-inline-block py-2" data-bs-toggle="dropdown">
+      <a href="#" class=" dropdown-head d-inline-block py-2" data-bs-toggle="dropdown">
         <%= image_tag user_avatar(current_user), class:"avatar-sm circle", alt: current_user.first_name + " " + current_user.last_name%>
       <div class="dropdown-menu dropdown-menu-end">
-        <div class="d-flex align-items-start border-bottom px-3 py-1 mb-2" style="width: 16rem;">
+        <div class="d-flex align-items-start border-bottom px-3 py-1 mb-2" style="min-width: 16rem; max-width: 18rem;">
           <%= image_tag user_avatar(current_user), class: "avatar-md circle", alt:""%>
-          <div class="ps-2">
+          <div class="dropdown-head-name ps-2">
             <h6 class="mb-0"><%= current_user.first_name + " " + current_user.last_name %></h6>
-            <div class="fs-xs py-2"><%= current_user.email %></div>
+            <div class="dropdown-head-eml py-2"><%= current_user.email %></div>
           </div>
         </div>
         <%= link_to edit_user_registration_path, class:"dropdown-item" do %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -10,13 +10,13 @@
     <div class="dropdown d-none d-lg-block order-lg-3 my-n2 me-3">
     <% if user_signed_in? %>
       <a href="#" class="d-inline-block py-2" data-bs-toggle="dropdown">
-        <%= image_tag user_avatar(current_user), class:"navbar-avatar-sm", alt: current_user.first_name + " " + current_user.last_name%>
+        <%= image_tag user_avatar(current_user), class:"avatar-sm circle", alt: current_user.first_name + " " + current_user.last_name%>
       <div class="dropdown-menu dropdown-menu-end">
         <div class="d-flex align-items-start border-bottom px-3 py-1 mb-2" style="width: 16rem;">
-          <%= image_tag user_avatar(current_user), class: "navbar-avatar-lg", alt:""%>
+          <%= image_tag user_avatar(current_user), class: "avatar-md circle", alt:""%>
           <div class="ps-2">
             <h6 class="fs-base mb-0"><%= current_user.first_name + " " + current_user.last_name %></h6>
-            <div class="fs-xs py-2"><%= current_user.email %></div>
+            <div class="fs-8 py-2"><%= current_user.email %></div>
           </div>
         </div>
         <%= link_to edit_user_registration_path, class:"dropdown-item" do %>


### PR DESCRIPTION
several changes were implemented:
- reduced avatar sizes overall and updated stylesheets
- reduced font size for the email & changed colour
- add a `max-width` to the container so that extra-long emails stretch the dropdown menu only a bit
- add `overflow-hidden` for when the email address is longer than `max-width`
- some refactoring